### PR TITLE
fix(app): preserve Brave bang redirects

### DIFF
--- a/Braver Search/Shared (Extension)/Resources/background.js
+++ b/Braver Search/Shared (Extension)/Resources/background.js
@@ -2,6 +2,8 @@
 
 console.log("Braver Search: Background script loaded");
 
+const BANG_REDIRECT_WINDOW_MS = 5000;
+
 const SEARCH_ENGINE_HOSTS = [
     'google.com',
     'google.co.uk',
@@ -17,6 +19,8 @@ const SEARCH_ENGINE_HOSTS = [
     'www.yandex.com'
 ];
 
+const pendingBangRedirects = new Map();
+
 function isSupportedSearchEngine(url) {
     // Check if the hostname matches
     if (!SEARCH_ENGINE_HOSTS.some(domain => url.hostname === domain)) {
@@ -31,6 +35,53 @@ function isSupportedSearchEngine(url) {
     }
     
     return searchPaths.some(path => url.pathname === path || url.pathname === path + '/');
+}
+
+function isBraveSearchUrl(url) {
+    if (url.hostname !== 'search.brave.com') {
+        return false;
+    }
+
+    return url.pathname === '/search' || url.pathname === '/search/';
+}
+
+function findBangToken(query) {
+    if (!query) {
+        return null;
+    }
+
+    const tokens = query.trim().split(/\s+/);
+    return tokens.find(token => /^![a-z0-9][a-z0-9-]*$/i.test(token))?.toLowerCase() ?? null;
+}
+
+function rememberBangRedirect(details, bangToken) {
+    if (!bangToken || typeof details.tabId !== 'number' || details.tabId < 0) {
+        return;
+    }
+
+    pendingBangRedirects.set(details.tabId, {
+        bangToken,
+        expiresAt: Date.now() + BANG_REDIRECT_WINDOW_MS
+    });
+}
+
+function shouldSkipRedirectForBang(details) {
+    if (typeof details.tabId !== 'number' || details.tabId < 0) {
+        return false;
+    }
+
+    const pendingBangRedirect = pendingBangRedirects.get(details.tabId);
+    if (!pendingBangRedirect) {
+        return false;
+    }
+
+    if (pendingBangRedirect.expiresAt <= Date.now()) {
+        pendingBangRedirects.delete(details.tabId);
+        return false;
+    }
+
+    pendingBangRedirects.delete(details.tabId);
+    return true;
 }
 
 // Function to check if redirect is enabled
@@ -104,6 +155,19 @@ browser.webNavigation.onBeforeNavigate.addListener(async (details) => {
         
         try {
             const url = new URL(details.url);
+            const searchQuery = url.searchParams.get('q');
+
+            if (searchQuery && isBraveSearchUrl(url)) {
+                const bangToken = findBangToken(searchQuery);
+                if (bangToken) {
+                    console.log("Braver Search: Remembering Brave bang search", {
+                        tabId: details.tabId,
+                        bangToken
+                    });
+                    rememberBangRedirect(details, bangToken);
+                }
+                return;
+            }
             
             // Skip URLs that are too complex or likely not search queries
             if (details.url.includes('%2F%2F') || url.pathname.length > 30) {
@@ -119,8 +183,7 @@ browser.webNavigation.onBeforeNavigate.addListener(async (details) => {
                 });
                 return;
             }
-            
-            const searchQuery = url.searchParams.get('q');
+
             console.log("Braver Search: Search query found", { 
                 url: url.toString(), 
                 hostname: url.hostname,
@@ -129,6 +192,13 @@ browser.webNavigation.onBeforeNavigate.addListener(async (details) => {
             });
             
             if (searchQuery) {
+                if (shouldSkipRedirectForBang(details)) {
+                    console.log("Braver Search: Skipping redirect for Brave bang search", {
+                        tabId: details.tabId
+                    });
+                    return;
+                }
+
                 // More sophisticated check to distinguish URLs from legitimate searches
                 const isLikelyURL = (query) => {
                     // If it's very long, likely a complex URL

--- a/Braver Search/Tests/JavaScript/background.test.js
+++ b/Braver Search/Tests/JavaScript/background.test.js
@@ -219,6 +219,37 @@ describe('Background Script', () => {
             );
         });
 
+        it('should skip one redirect after a Brave bang search in the same tab', async () => {
+            await navigationListener({
+                tabId: 42,
+                url: 'https://search.brave.com/search?q=cats%20!g'
+            });
+
+            await navigationListener({
+                tabId: 42,
+                url: 'https://google.com/search?q=cats'
+            });
+
+            expect(browser.tabs.update).not.toHaveBeenCalled();
+        });
+
+        it('should still redirect supported searches without a Brave bang', async () => {
+            await navigationListener({
+                tabId: 42,
+                url: 'https://search.brave.com/search?q=cats'
+            });
+
+            await navigationListener({
+                tabId: 42,
+                url: 'https://google.com/search?q=cats'
+            });
+
+            expect(browser.tabs.update).toHaveBeenCalledWith(
+                42,
+                { url: 'https://search.brave.com/search?q=cats' }
+            );
+        });
+
         it('should track enabled state changes from storage updates', () => {
             storageChangeListener(
                 {


### PR DESCRIPTION
## Summary
Preserve Brave Search bang redirects so Braver Search does not immediately pull those searches back to Brave.

## Problem
Braver Search treated destination search URLs the same regardless of how they were reached. When a Brave Search bang like `!g`, `!y`, or `!yt` handed the tab off to another engine, the extension saw that follow-up navigation and redirected it back to Brave.

## Solution
Record a short-lived, tab-scoped marker when a Brave Search query contains a bang token, then skip exactly one follow-up redirect in that same tab. This keeps Brave-originated bang handoffs working while leaving the default redirect behavior unchanged for normal searches.

Direct searches on a specific engine are still not exempted by this change. Users can handle those cases through Safari's extension website settings by denying Braver Search on specific sites or engines.

## Changes
- Update the extension redirect flow to recognize Brave Search bang queries and bypass one follow-up redirect in the same tab.
- Add regression coverage for bang redirects and for standard searches that should still be redirected.
- Closes #1.

## Testing
`npm test -- --runInBand --runTestsByPath 'Braver Search/Tests/JavaScript/background.test.js'`
