### PR TITLE
feat(ios): move donations above review card

### DIFF
--- a/Braver Search/iOS (App)/MainView.swift
+++ b/Braver Search/iOS (App)/MainView.swift
@@ -41,11 +41,12 @@ struct MainView: View {
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 18) {
                         activationCard
-                        reviewCard
 
                         if monetization.canShowSupport {
                             supportSection
                         }
+
+                        reviewCard
 
                         utilityLinks
                     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the iOS main screen so the "Give Thanks" donation section appears **above** the "Rate & Review" card.

New order: `Finish Safari Setup` → `Give Thanks` (donations) → `Rate & Review` → utility links.

The setup/activation card stays on top since it's the primary CTA.

## Scope note

This only touches **iOS** (`MainView.swift`), which is the vertical stack the request describes.

**macOS was intentionally left alone.** On macOS (`Main.html`), the review card is in a 2-column grid *beside* the status card, and donations are already a separate full-width section *below* that grid. "Moving donations higher" there would require pulling the review card out of the grid and restructuring that layout — a design change I didn't want to make without sign-off. Let me know if you want the macOS layout reworked to match.

## Testing

- [ ] Build iOS app; confirm donation section renders above the review card
- [ ] Confirm donation section still only shows for grandfathered users
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1e01-caa2-7c5d-aa18-2c7f9bed0968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1e01-caa2-7c5d-aa18-2c7f9bed0968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

